### PR TITLE
fix: make it so postinstall scripts module works on bootc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "readymade"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "backhand",
  "bytesize",

--- a/src/backend/install.rs
+++ b/src/backend/install.rs
@@ -278,16 +278,12 @@ impl InstallationState {
                         }
                     }
                 }
-                if !Command::new("umount")
+                Command::new("umount")
                     .arg("-R")
                     .arg("-l")
                     .arg(tmproot)
-                    .status()
-                    .wrap_err("failed to run umount")?
-                    .success()
-                {
-                    return Err(eyre!("`umount -R {tmproot:?}` failed"));
-                }
+                    .spawn()
+                    .ok();
             }
         }
 
@@ -403,16 +399,12 @@ impl InstallationState {
 
         Command::new("sync").arg("-f").arg(targetroot).spawn().ok();
 
-        if !Command::new("umount")
+        Command::new("umount")
             .arg("-R")
             .arg("-l")
             .arg(targetroot)
-            .status()
-            .wrap_err("failed to run umount")?
-            .success()
-        {
-            return Err(eyre!("`umount -R {targetroot:?}` failed"));
-        }
+            .spawn()
+            .ok();
 
         Ok(())
     }

--- a/src/backend/install.rs
+++ b/src/backend/install.rs
@@ -265,11 +265,9 @@ impl InstallationState {
 
             for f in std::fs::read_dir(tmproot)? {
                 let f = f?;
-                if let Some(filename) = f.file_name().into_string().ok() {
+                if let Ok(filename) = f.file_name().into_string() {
                     match filename.as_str() {
-                        "boot" => (),
-                        "ostree" => (),
-                        ".bootc-aleph.json" => (),
+                        "boot" | "ostree" | "efi" | ".bootc-aleph.json" => (),
                         _ => {
                             if f.file_type()?.is_dir() {
                                 Command::new("umount").arg("-R").arg(f.path()).spawn().ok();
@@ -282,6 +280,7 @@ impl InstallationState {
                 }
                 if !Command::new("umount")
                     .arg("-R")
+                    .arg("-l")
                     .arg(tmproot)
                     .status()
                     .wrap_err("failed to run umount")?
@@ -403,6 +402,7 @@ impl InstallationState {
 
         if !Command::new("umount")
             .arg("-R")
+            .arg("-l")
             .arg(targetroot)
             .status()
             .wrap_err("failed to run umount")?

--- a/src/backend/install.rs
+++ b/src/backend/install.rs
@@ -316,6 +316,7 @@ impl InstallationState {
         Ok(())
     }
 
+    #[allow(clippy::unwrap_in_result)]
     fn bootc_mount(
         targetroot: &Path,
         output: &RepartOutput,
@@ -387,7 +388,7 @@ impl InstallationState {
 
         let targetroot = tempfile::tempdir()?;
         let targetroot = targetroot.path();
-        InstallationState::bootc_mount(targetroot, output, passphrase)?;
+        Self::bootc_mount(targetroot, output, passphrase)?;
 
         if !Command::new("bootc")
             .args(["install", "to-filesystem"])
@@ -399,6 +400,8 @@ impl InstallationState {
         {
             return Err(eyre!("`bootc install to-filesystem` failed"));
         }
+
+        Command::new("sync").arg("-f").arg(targetroot).spawn().ok();
 
         if !Command::new("umount")
             .arg("-R")

--- a/src/backend/install.rs
+++ b/src/backend/install.rs
@@ -270,7 +270,6 @@ impl InstallationState {
                         "boot" | "ostree" | "efi" | ".bootc-aleph.json" => (),
                         _ => {
                             if f.file_type()?.is_dir() {
-                                Command::new("umount").arg("-R").arg(f.path()).spawn().ok();
                                 std::fs::remove_dir_all(f.path())?;
                             } else {
                                 std::fs::remove_file(f.path()).ok();

--- a/src/backend/install.rs
+++ b/src/backend/install.rs
@@ -257,24 +257,26 @@ impl InstallationState {
             Some(repartcfg_export),
         )?;
 
-        // Cleanup mount files from bootc thing
-        let tmproot = tempfile::tempdir()?;
-        let tmproot = tmproot.path();
-        InstallationState::bootc_mount(tmproot, &repart_out, self.encryption_key.as_deref())?;
+        if self.bootc_imgref.is_some() {
+            // Cleanup mount files from bootc thing
+            let tmproot = tempfile::tempdir()?;
+            let tmproot = tmproot.path();
+            Self::bootc_mount(tmproot, &repart_out, self.encryption_key.as_deref())?;
 
-        for f in std::fs::read_dir(tmproot)? {
-            let f = f?;
-            if let Some(filename) = f.file_name().into_string().ok() {
-                match filename.as_str() {
-                    "boot" => (),
-                    "ostree" => (),
-                    ".bootc-aleph.json" => (),
-                    _ => {
-                        if f.file_type()?.is_dir() {
-                            Command::new("umount").arg("-R").arg(f.path()).spawn().ok();
-                            std::fs::remove_dir_all(f.path())?;
-                        } else {
-                            std::fs::remove_file(f.path()).ok();
+            for f in std::fs::read_dir(tmproot)? {
+                let f = f?;
+                if let Some(filename) = f.file_name().into_string().ok() {
+                    match filename.as_str() {
+                        "boot" => (),
+                        "ostree" => (),
+                        ".bootc-aleph.json" => (),
+                        _ => {
+                            if f.file_type()?.is_dir() {
+                                Command::new("umount").arg("-R").arg(f.path()).spawn().ok();
+                                std::fs::remove_dir_all(f.path())?;
+                            } else {
+                                std::fs::remove_file(f.path()).ok();
+                            }
                         }
                     }
                 }

--- a/src/backend/install.rs
+++ b/src/backend/install.rs
@@ -280,6 +280,15 @@ impl InstallationState {
                         }
                     }
                 }
+                if !Command::new("umount")
+                    .arg("-R")
+                    .arg(tmproot)
+                    .status()
+                    .wrap_err("failed to run umount")?
+                    .success()
+                {
+                    return Err(eyre!("`umount -R {tmproot:?}` failed"));
+                }
             }
         }
 

--- a/src/backend/install.rs
+++ b/src/backend/install.rs
@@ -271,20 +271,12 @@ impl InstallationState {
                     ".bootc-aleph.json" => (),
                     _ => {
                         if f.file_type()?.is_dir() {
-                            if !Command::new("umount")
-                                .arg("-R")
-                                .arg(f.path())
-                                .status()
-                                .wrap_err("failed to run umount")?
-                                .success()
-                            {
-                                return Err(eyre!("`umount -R {f:?}` failed"));
-                            }
+                            Command::new("umount").arg("-R").arg(f.path()).spawn().ok();
                             std::fs::remove_dir_all(f.path())?;
                         } else {
-                            std::fs::remove_file(f.path());
+                            std::fs::remove_file(f.path()).ok();
                         }
-                    },
+                    }
                 }
             }
         }
@@ -314,67 +306,66 @@ impl InstallationState {
         Ok(())
     }
 
-
-fn bootc_mount(
-    targetroot: &Path,
-    output: &RepartOutput,
-    passphrase: Option<&str>,
-) -> Result<()> {
-    let mut decrypted_partitions: std::collections::HashMap<String, PathBuf> =
-        std::collections::HashMap::new();
-    let mps = output.mountpoints().map(|(mntpoint, node)| {
-        let mp = PathBuf::from(mntpoint);
-        if !crate::backend::repart_output::is_luks(&node) {
-            return Result::<_, color_eyre::eyre::Error>::Ok((PathBuf::from(node), mp));
-        }
-        let node = if let Some(mapper) = decrypted_partitions.get(&node) {
-            mapper.clone()
-        } else {
-            let pass = passphrase.ok_or_eyre("Passphrase is empty when is_luks() is true")?;
-            // We need to sanitize the label for the mapper device name, as it can't contain slashes
-            //
-            // I forgot to account for this when I refactored it -Cappy
-            //
-            let label = crate::backend::repart_output::generate_unique_mapper_label(mntpoint);
-            // XXX: This introduces some weird ordering issues with generate_fstab when decrypting from here
-            // Because generate_fstab() assumes that the partitions are decrypted already.
-            //
-            // todo: add some global cache for decrypted partitions
-            let mapper = crate::backend::repart_output::luks_decrypt(&node, pass, &label)?;
-            decrypted_partitions.insert(node.clone(), mapper.clone());
-            mapper
-        };
-        Result::<_, color_eyre::eyre::Error>::Ok((node, mp))
-    });
-    let mps = mps.try_collect::<_, Vec<_>, _>()?.into_iter();
-    let mut mps = mps.sorted_by(|(_, a), (_, b)| {
-        match (a.components().count(), b.components().count()) {
-            (1, _) if a.components().next() == Some(std::path::Component::RootDir) => {
-                std::cmp::Ordering::Less
-            } // root dir
-            (_, 1) if b.components().next() == Some(std::path::Component::RootDir) => {
-                std::cmp::Ordering::Greater
-            } // root dir
-            (x, y) if x == y => a.cmp(b),
-            (x, y) => x.cmp(&y),
-        }
-    });
-    mps.try_for_each(|(source, mntpoint)| {
-        let target = targetroot.join(mntpoint.strip_prefix("/").expect("cannot strip /"));
-        tracing::debug!(?source, ?target, "mounting");
-        std::fs::create_dir_all(&target)?;
-        // use shell to mount manually since sys_mount is buggy
-        if !Command::new("mount")
-            .args([&source, &target])
-            .status()
-            .wrap_err("cannot run mount")?
-            .success()
-        {
-            return Err(eyre!("`mount {source:?} → {target:?}` failed"));
-        }
-        Ok(())
-    })
-}
+    fn bootc_mount(
+        targetroot: &Path,
+        output: &RepartOutput,
+        passphrase: Option<&str>,
+    ) -> Result<()> {
+        let mut decrypted_partitions: std::collections::HashMap<String, PathBuf> =
+            std::collections::HashMap::new();
+        let mps = output.mountpoints().map(|(mntpoint, node)| {
+            let mp = PathBuf::from(mntpoint);
+            if !crate::backend::repart_output::is_luks(&node) {
+                return Result::<_, color_eyre::eyre::Error>::Ok((PathBuf::from(node), mp));
+            }
+            let node = if let Some(mapper) = decrypted_partitions.get(&node) {
+                mapper.clone()
+            } else {
+                let pass = passphrase.ok_or_eyre("Passphrase is empty when is_luks() is true")?;
+                // We need to sanitize the label for the mapper device name, as it can't contain slashes
+                //
+                // I forgot to account for this when I refactored it -Cappy
+                //
+                let label = crate::backend::repart_output::generate_unique_mapper_label(mntpoint);
+                // XXX: This introduces some weird ordering issues with generate_fstab when decrypting from here
+                // Because generate_fstab() assumes that the partitions are decrypted already.
+                //
+                // todo: add some global cache for decrypted partitions
+                let mapper = crate::backend::repart_output::luks_decrypt(&node, pass, &label)?;
+                decrypted_partitions.insert(node.clone(), mapper.clone());
+                mapper
+            };
+            Result::<_, color_eyre::eyre::Error>::Ok((node, mp))
+        });
+        let mps = mps.try_collect::<_, Vec<_>, _>()?.into_iter();
+        let mut mps = mps.sorted_by(|(_, a), (_, b)| {
+            match (a.components().count(), b.components().count()) {
+                (1, _) if a.components().next() == Some(std::path::Component::RootDir) => {
+                    std::cmp::Ordering::Less
+                } // root dir
+                (_, 1) if b.components().next() == Some(std::path::Component::RootDir) => {
+                    std::cmp::Ordering::Greater
+                } // root dir
+                (x, y) if x == y => a.cmp(b),
+                (x, y) => x.cmp(&y),
+            }
+        });
+        mps.try_for_each(|(source, mntpoint)| {
+            let target = targetroot.join(mntpoint.strip_prefix("/").expect("cannot strip /"));
+            tracing::debug!(?source, ?target, "mounting");
+            std::fs::create_dir_all(&target)?;
+            // use shell to mount manually since sys_mount is buggy
+            if !Command::new("mount")
+                .args([&source, &target])
+                .status()
+                .wrap_err("cannot run mount")?
+                .success()
+            {
+                return Err(eyre!("`mount {source:?} → {target:?}` failed"));
+            }
+            Ok(())
+        })
+    }
 
     #[allow(clippy::unwrap_in_result)]
     fn bootc_copy(&self, output: &RepartOutput, passphrase: Option<&str>) -> Result<()> {
@@ -755,8 +746,6 @@ impl InstallationType {
         Ok(())
     }
 }
-
-
 
 #[cfg(test)]
 mod tests {

--- a/src/backend/install.rs
+++ b/src/backend/install.rs
@@ -270,7 +270,7 @@ impl InstallationState {
                         "boot" | "ostree" | "efi" | ".bootc-aleph.json" => (),
                         _ => {
                             if f.file_type()?.is_dir() {
-                                std::fs::remove_dir_all(f.path())?;
+                                std::fs::remove_dir_all(f.path()).ok();
                             } else {
                                 std::fs::remove_file(f.path()).ok();
                             }

--- a/src/backend/postinstall/script.rs
+++ b/src/backend/postinstall/script.rs
@@ -12,8 +12,7 @@ impl PostInstallModule for Script {
     #[allow(clippy::unwrap_in_result)]
     fn run(&self, context: &Context) -> Result<()> {
         if std::fs::exists("/etc/readymade/postinstall.sh").is_ok_and(|x| x) {
-            let cmd = std::process::Command::new("sh")
-                .arg("/etc/readymade/postinstall.sh")
+            let cmd = std::process::Command::new("/etc/readymade/postinstall.sh")
                 .stdin(std::process::Stdio::piped())
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped())
@@ -23,8 +22,7 @@ impl PostInstallModule for Script {
         }
 
         if std::fs::exists("/usr/share/readymade/postinstall.sh").is_ok_and(|x| x) {
-            let cmd = std::process::Command::new("sh")
-                .arg("/usr/share/readymade/postinstall.sh")
+            let cmd = std::process::Command::new("/usr/share/readymade/postinstall.sh")
                 .stdin(std::process::Stdio::piped())
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped())
@@ -37,8 +35,7 @@ impl PostInstallModule for Script {
             for f in std::fs::read_dir("/etc/readymade/postinstall.d/")? {
                 let f = f?;
                 if f.metadata()?.is_file() && f.metadata()?.permissions().mode() & 0o111 != 0 {
-                    let cmd = std::process::Command::new("sh")
-                        .arg(f.path())
+                    let cmd = std::process::Command::new(f.path())
                         .stdin(std::process::Stdio::piped())
                         .stdout(std::process::Stdio::piped())
                         .stderr(std::process::Stdio::piped())
@@ -52,8 +49,7 @@ impl PostInstallModule for Script {
             for f in std::fs::read_dir("/usr/share/readymade/postinstall.d/")? {
                 let f = f?;
                 if f.metadata()?.is_file() && f.metadata()?.permissions().mode() & 0o111 != 0 {
-                    let cmd = std::process::Command::new("sh")
-                        .arg(f.path())
+                    let cmd = std::process::Command::new(f.path())
                         .stdin(std::process::Stdio::piped())
                         .stdout(std::process::Stdio::piped())
                         .stderr(std::process::Stdio::piped())

--- a/src/backend/repart_output.rs
+++ b/src/backend/repart_output.rs
@@ -295,16 +295,12 @@ impl RepartOutput {
             container.add_mount(mnt_target, PathBuf::from("/sys/firmware/efi/efivars"));
         }
 
-        // expose host rootfs
-        container.add_mount(
-            MountTarget {
-                target: PathBuf::from("/run/host"),
-                fstype: None,
-                flags: MountFlags::BIND,
-                data: None,
-            },
-            PathBuf::from("/"),
-        );
+        container.host_bind_mount();
+        container.bind_mount(PathBuf::from("/run/host/usr"), PathBuf::from("/usr"));
+        container.bind_mount(PathBuf::from("/run/host/etc"), PathBuf::from("/etc"));
+        container.bind_mount(PathBuf::from("/run/host/lib"), PathBuf::from("/lib"));
+        container.bind_mount(PathBuf::from("/run/host/lib64"), PathBuf::from("/lib64"));
+        container.bind_mount(PathBuf::from("/run/host/bin"), PathBuf::from("/bin"));
 
         Ok(container)
     }


### PR DESCRIPTION
Bootc needs some more mounting, and this PR makes it so the scripts run via shebangs.

WIP: we need to clean all the mountpoints off of the bootc rootfs after closing the container
