### PR TITLE
fix(bootc): decouple mounting/unmounting logic so bootc_copy's `/boot` doesnt break

### DIFF
--- a/src/backend/install.rs
+++ b/src/backend/install.rs
@@ -248,7 +248,24 @@ impl InstallationState {
 
         let repartcfg_export = super::export::SystemdRepartData::get_configs(&cfgdir)?;
 
-        self.bootc_copy(&repart_out, self.encryption_key.as_deref())?;
+
+        if self.bootc_imgref.is_some() {
+            let tmproot = tempfile::tempdir()?;
+            let bootc_rootfs_mountpoint = tmproot.path();
+            println!("MY_DEBUG: mounting bootc");
+            Self::bootc_mount(
+                bootc_rootfs_mountpoint,
+                &repart_out,
+                self.encryption_key.as_deref(),
+            )?;
+            println!("MY_DEBUG: copying bootc");
+            self.bootc_copy(bootc_rootfs_mountpoint)?;
+            Command::new("sync")
+                .arg("-f")
+                .arg(bootc_rootfs_mountpoint)
+                .status().ok();
+            Command::new("umount").arg("-R").arg("-l").arg(bootc_rootfs_mountpoint).status().ok();
+        }
 
         tracing::info!("Copying files done, Setting up system...");
         self.setup_system(
@@ -260,15 +277,22 @@ impl InstallationState {
         if self.bootc_imgref.is_some() {
             // Cleanup mount files from bootc thing
             let tmproot = tempfile::tempdir()?;
-            let tmproot = tmproot.path();
-            Self::bootc_mount(tmproot, &repart_out, self.encryption_key.as_deref())?;
-            Self::bootc_cleanup(tmproot)?;
-            Command::new("umount")
-                .arg("-R")
-                .arg("-l")
-                .arg(tmproot)
-                .spawn()
+            let bootc_rootfs_mountpoint = tmproot.path();
+            println!("MY_DEBUG: mounting bootc");
+            Self::bootc_mount(
+                bootc_rootfs_mountpoint,
+                &repart_out,
+                self.encryption_key.as_deref(),
+            )?;
+            println!("MY_DEBUG: cleaning bootc");
+            Self::bootc_cleanup(bootc_rootfs_mountpoint)?;
+            println!("MY_DEBUG: syncing bootc");
+            Command::new("sync")
+                .arg("-f")
+                .arg(bootc_rootfs_mountpoint)
+                .status()
                 .ok();
+            Command::new("umount").arg("-R").arg(bootc_rootfs_mountpoint).spawn().ok();
         }
 
         if let InstallationType::ChromebookInstall = inst_type {
@@ -387,36 +411,25 @@ impl InstallationState {
     }
 
     #[allow(clippy::unwrap_in_result)]
-    fn bootc_copy(&self, output: &RepartOutput, passphrase: Option<&str>) -> Result<()> {
+    fn bootc_copy(&self, target_root: &Path) -> Result<()> {
         let Some(imgref) = &self.bootc_imgref else {
-            return Ok(());
+            return Err(eyre!(
+                "Bootc copy mode called without having imgref defined"
+            ));
         };
 
         tracing::info!(?imgref, "running bootc install to-filesystem");
 
-        let targetroot = tempfile::tempdir()?;
-        let targetroot = targetroot.path();
-        Self::bootc_mount(targetroot, output, passphrase)?;
-
         if !Command::new("bootc")
             .args(["install", "to-filesystem"])
             .args(["--source-imgref", imgref])
-            .arg(targetroot)
+            .arg(target_root)
             .status()
             .wrap_err("cannot run bootc")?
             .success()
         {
             return Err(eyre!("`bootc install to-filesystem` failed"));
         }
-
-        Command::new("sync").arg("-f").arg(targetroot).spawn().ok();
-
-        Command::new("umount")
-            .arg("-R")
-            .arg("-l")
-            .arg(targetroot)
-            .spawn()
-            .ok();
 
         Ok(())
     }

--- a/src/backend/install.rs
+++ b/src/backend/install.rs
@@ -257,9 +257,7 @@ impl InstallationState {
                 self.encryption_key.as_deref(),
             )?;
             self.bootc_copy(bootc_rootfs_mountpoint, self.encryption_key.as_deref())?;
-            Command::new("sync")
-                .status()
-                .ok();
+            Command::new("sync").status().ok();
             Command::new("umount")
                 .arg("-R")
                 .arg(bootc_rootfs_mountpoint)
@@ -284,9 +282,7 @@ impl InstallationState {
                 self.encryption_key.as_deref(),
             )?;
             Self::bootc_cleanup(bootc_rootfs_mountpoint)?;
-            Command::new("sync")
-                .status()
-                .ok();
+            Command::new("sync").status().ok();
             Command::new("umount")
                 .arg("-R")
                 .arg(bootc_rootfs_mountpoint)

--- a/src/backend/install.rs
+++ b/src/backend/install.rs
@@ -258,13 +258,10 @@ impl InstallationState {
             )?;
             self.bootc_copy(bootc_rootfs_mountpoint, self.encryption_key.as_deref())?;
             Command::new("sync")
-                .arg("-f")
-                .arg(bootc_rootfs_mountpoint)
                 .status()
                 .ok();
             Command::new("umount")
                 .arg("-R")
-                .arg("-l")
                 .arg(bootc_rootfs_mountpoint)
                 .status()
                 .ok();
@@ -288,14 +285,12 @@ impl InstallationState {
             )?;
             Self::bootc_cleanup(bootc_rootfs_mountpoint)?;
             Command::new("sync")
-                .arg("-f")
-                .arg(bootc_rootfs_mountpoint)
                 .status()
                 .ok();
             Command::new("umount")
                 .arg("-R")
                 .arg(bootc_rootfs_mountpoint)
-                .spawn()
+                .status()
                 .ok();
         }
 


### PR DESCRIPTION

There was some race condition that made `/boot` be deleted all the time, I just entirely decoupled mounting from the bootc thing straight up because it makes it easier to debug and I also made it so the umount and sync calls are blocking (makes it so `/boot` doesn't blow up)