### PR TITLE
feat: add bootc_target_imgref, bootc_sigpolicy and bootc_kargs

### DIFF
--- a/src/backend/install.rs
+++ b/src/backend/install.rs
@@ -436,11 +436,10 @@ impl InstallationState {
             args.push(target_imgref);
         }
         if let Some(bootc_kargs) = &self.bootc_kargs {
-            let args_vec: Vec<&str> = bootc_kargs
-                .iter()
-                .map(|e| format!("--karg={}", e))
-                .collect();
-            args.extend(args_vec);
+            bootc_kargs.iter().for_each(|e| {
+                args.push("--karg");
+                args.push(e);
+            });
         }
         if self.bootc_enforce_sigpolicy {
             args.push("--enforce-container-sigpolicy");

--- a/src/backend/install.rs
+++ b/src/backend/install.rs
@@ -436,7 +436,10 @@ impl InstallationState {
             args.push(target_imgref);
         }
         if let Some(bootc_kargs) = &self.bootc_kargs {
-            let args_vec: Vec<&str> = bootc_kargs.iter().map(|e| e.as_str()).collect();
+            let args_vec: Vec<&str> = bootc_kargs
+                .iter()
+                .map(|e| format!("--karg={}", e))
+                .collect();
             args.extend(args_vec);
         }
         if self.bootc_enforce_sigpolicy {

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -25,6 +25,9 @@ pub struct Install {
     #[serde(default)]
     pub copy_mode: CopyMode,
     pub bootc_imgref: Option<String>,
+    pub bootc_target_imgref: Option<String>,
+    pub bootc_enforce_sigpolicy: bool,
+    pub bootc_kargs: Option<Vec<String>>,
 }
 
 #[derive(Deserialize, Default, Debug, Clone, PartialEq, Eq)]
@@ -109,6 +112,9 @@ mod tests {
                     allowed_installtypes: vec![InstallationType::ChromebookInstall],
                     copy_mode: CopyMode::Bootc,
                     bootc_imgref: None,
+                    bootc_target_imgref: None,
+                    bootc_enforce_sigpolicy: false,
+                    bootc_kargs: Some(vec![]),
                 },
                 postinstall: vec![
                     crate::backend::postinstall::grub2::GRUB2.into(),

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -26,6 +26,7 @@ pub struct Install {
     pub copy_mode: CopyMode,
     pub bootc_imgref: Option<String>,
     pub bootc_target_imgref: Option<String>,
+    #[serde(default)]
     pub bootc_enforce_sigpolicy: bool,
     pub bootc_kargs: Option<Vec<String>>,
 }

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -115,7 +115,7 @@ mod tests {
                     bootc_imgref: None,
                     bootc_target_imgref: None,
                     bootc_enforce_sigpolicy: false,
-                    bootc_kargs: Some(vec![]),
+                    bootc_kargs: None,
                 },
                 postinstall: vec![
                     crate::backend::postinstall::grub2::GRUB2.into(),


### PR DESCRIPTION

This adds support for signed bootc images, custom bootc kargs via the config file, and custom imgrefs for target if necessary
Fixes: https://github.com/ublue-os/titanoboa/issues/76