### PR TITLE
fix: always show InstallationType page

### DIFF
--- a/src/pages/confirmation.rs
+++ b/src/pages/confirmation.rs
@@ -90,11 +90,7 @@ page!(Confirmation:
             set_label: &t!("prev"),
             add_css_class: "large-button",
             connect_clicked => ConfirmationPageMsg::Navigate(NavigationAction::GoTo(
-                if crate::CONFIG.read().install.allowed_installtypes.len() == 1 {
-                    crate::Page::Destination
-                } else {
                     crate::Page::InstallationType
-                }
             )),
         },
 


### PR DESCRIPTION
We need this to always be shown due to FDE

Partial fix for: https://github.com/ublue-os/titanoboa/issues/79

![image](https://github.com/user-attachments/assets/76f9ec61-232f-41d9-89fe-8720b890d099)
