### PR TITLE
feat(bootc): add arbitrary argument support

### DIFF
--- a/src/backend/install.rs
+++ b/src/backend/install.rs
@@ -60,6 +60,7 @@ pub struct InstallationState {
     pub bootc_target_imgref: Option<String>,
     pub bootc_enforce_sigpolicy: bool,
     pub bootc_kargs: Option<Vec<String>>,
+    pub bootc_args: Option<Vec<String>>,
 }
 
 impl From<&crate::cfg::ReadymadeConfig> for InstallationState {
@@ -81,6 +82,7 @@ impl From<&crate::cfg::ReadymadeConfig> for InstallationState {
                 .or_else(|| std::env::var("TARGET_COPY_SOURCE").ok()),
             bootc_enforce_sigpolicy: value.install.bootc_enforce_sigpolicy,
             bootc_kargs: value.install.bootc_kargs.clone(),
+            bootc_args: value.install.bootc_args.clone(),
             ..Self::default()
         }
     }
@@ -433,6 +435,7 @@ impl InstallationState {
                 self.bootc_enforce_sigpolicy
                     .then_some("--enforce-container-sigpolicy"),
             )
+            .args((self.bootc_args.iter().flatten()).flat_map(|e| [e]))
             .status()
             .wrap_err("cannot run bootc")?
             .success()

--- a/src/backend/install.rs
+++ b/src/backend/install.rs
@@ -435,7 +435,7 @@ impl InstallationState {
                 self.bootc_enforce_sigpolicy
                     .then_some("--enforce-container-sigpolicy"),
             )
-            .args((self.bootc_args.iter().flatten()).flat_map(|e| [e]))
+            .args(self.bootc_args.iter().flatten())
             .status()
             .wrap_err("cannot run bootc")?
             .success()

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -29,6 +29,7 @@ pub struct Install {
     #[serde(default)]
     pub bootc_enforce_sigpolicy: bool,
     pub bootc_kargs: Option<Vec<String>>,
+    pub bootc_args: Option<Vec<String>>,
 }
 
 #[derive(Deserialize, Default, Debug, Clone, PartialEq, Eq)]
@@ -116,6 +117,7 @@ mod tests {
                     bootc_target_imgref: None,
                     bootc_enforce_sigpolicy: false,
                     bootc_kargs: None,
+                    bootc_args: None,
                 },
                 postinstall: vec![
                     crate::backend::postinstall::grub2::GRUB2.into(),


### PR DESCRIPTION
This is for hotfixing options that bootc may need to have at some point,
like, for offline ISOs on `bootc 1.1.6` we need `--skip-fetch-check`,
but `bootc 1.1.7` already has that by default, and we dont wanna do this
all the time we need a quick fix like this
