### PR TITLE
chore: dont include configs on the main readymade package

### DIFF
--- a/ci/readymade.spec
+++ b/ci/readymade.spec
@@ -48,7 +48,6 @@ sed -i 's/^\[profile\.rpm\]/[profile.rpm]\ndebug-assertions = true/' .cargo/conf
 %_datadir/polkit-1/actions/com.fyralabs.pkexec.readymade.policy
 %{_datadir}/applications/com.fyralabs.Readymade.desktop
 %{_datadir}/icons/hicolor/*/apps/com.fyralabs.Readymade.*
-%_datadir/readymade
 
 %files config-ultramarine
 %_sysconfdir/readymade.toml


### PR DESCRIPTION

This will let downstreams create packages for their custom stuff under `/usr/share/readymade`, as we dont need
the templates or anything that the install script does really