### PR TITLE
fix: Make tests pass

### DIFF
--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -153,6 +153,7 @@ mod tests {
             )
             .unwrap(),
             ReadymadeConfig {
+                no_langpage: false,
                 distro: Distro {
                     name: "Ultramarine Linux".into(),
                     icon: "fedora-logo-icon".into(),


### PR DESCRIPTION
Fixes a missing field on the readymade config struct on the tests