### PR TITLE
fix(.gitmodules): Update submodule link

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "taidan_proc_macros"]
 	path = taidan_proc_macros
-	url = git@github.com:FyraLabs/rdms_proc_macros.git
+	url = https://github.com/FyraLabs/rdms_proc_macros.git


### PR DESCRIPTION
This was using an outdated submodule method, which is why it wasn't recursively clonable.