### PR TITLE
Use UTF-8 locales for language settings

### DIFF
--- a/src/backend/postinstall/language.rs
+++ b/src/backend/postinstall/language.rs
@@ -9,7 +9,9 @@ pub struct Language;
 impl PostInstallModule for Language {
     fn run(&self, context: &Context) -> Result<()> {
         // use UTF-8 locale, since the non-UTF-8 ones break stuff
-        let lang = format!("{}.UTF-8", context.lang).as_bytes();
+        let lang = format!("{}.UTF-8", context.lang);
+        // shadowing here because format!() has shit lifetime
+        let lang = lang.as_bytes();
         // `LOCALE.CONF(5)`: /etc/locale.conf
         std::fs::write(
             "/etc/locale.conf",


### PR DESCRIPTION
Update the language setting to use UTF-8 locales to prevent issues caused by non-UTF-8 locales.

Fixes instances of https://github.com/starship/starship/issues/5798 and more locale issues